### PR TITLE
Striker45 mag size fix

### DIFF
--- a/lua/arc9/common/attachments_bulk/mw19_weapon_submachineguns.lua
+++ b/lua/arc9/common/attachments_bulk/mw19_weapon_submachineguns.lua
@@ -1685,7 +1685,7 @@ ATT.BulletBones = {
 	[4] = {"j_bullet4","j_ammo4"},
 }
 
-ATT.ClipSizeAdd = 20
+ATT.ClipSizeAdd = 15
 
 if !warzonestats then -- Regular Stats
 	ATT.ReloadTimeMult = 1.1
@@ -1721,7 +1721,7 @@ ATT.BulletBones = {
 	[4] = {"j_bullet4","j_ammo4"},
 }
 
-ATT.ClipSizeAdd = 20
+ATT.ClipSizeAdd = 15
 
 ATT.ReloadTimeMult = 1.1
 ATT.DeployTimeMult = 1.05


### PR DESCRIPTION
Changed ATT.ClipSizeAdd to 15 to correct the magazine capacities for both the 45 Round Mags and 45 Round 9mm mags for the Striker45.