### PR TITLE
ASVAL and Fennec mag firemode fixes

### DIFF
--- a/lua/arc9/common/attachments_bulk/mw19_weapon_assaultrifles.lua
+++ b/lua/arc9/common/attachments_bulk/mw19_weapon_assaultrifles.lua
@@ -4324,6 +4324,13 @@ ATT.BulletBones = {
 
 ATT.ClipSizeAdd = -10
 
+ATT.Firemodes = {
+	{
+		Mode = 1,
+		PoseParam = 1,
+	},
+}
+
 if !warzonestats then -- Regular Stats
 	ATT.AimDownSightsTimeMult = 0.93
 	ATT.DeployTimeMult = 0.88

--- a/lua/arc9/common/attachments_bulk/mw19_weapon_submachineguns.lua
+++ b/lua/arc9/common/attachments_bulk/mw19_weapon_submachineguns.lua
@@ -2380,6 +2380,18 @@ ATT.DropMagazineModel = "models/weapons/cod2019/attachs/weapons/vector/attachmen
 ATT.BoneMerge = true
 
 ATT.ClipSizeAdd = -13
+ATT.RunawayBurst = true
+
+ATT.Firemodes = {
+	{
+		Mode = 2,
+		PoseParam = 0,
+	},
+	{
+		Mode = 1,
+		PoseParam = 1,
+	},
+}
 
 if !warzonestats then -- Regular Stats
 	ATT.ReloadTimeMult = 0.9


### PR DESCRIPTION
- Fix for AS VAL's 10-Round SPP mag not defaulting to semi-auto.
- Fix for Fennec's 12-Round HP mag not defaulting to 2-round burst and semi-auto.